### PR TITLE
Add meta-cell corridor pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,9 @@ The engine instantiates Levin’s decentralization by assigning every integer �
 
 This is not a practical competitor to GNFS / deployed RSA.
 
+### Meta-Cell Corridor Mode (hierarchical Levin V2)
+For the 127-bit regime, dense ±50M bands around √N proved brittle. The meta-cell pipeline elevates Levin sorting: Stage 1 ranks *corridors* (ranges) by resonance energy estimated from sparse samples; Stage 2 expands only the top-ranked corridors into dense atomic cells for the usual Levin swaps and trial certification. This two-stage sort turns “guess the band” into “global sparse scan → local dense zoom,” preserving the geometry-first, arithmetic-last doctrine while keeping memory within guardrails.
+
 ## Ladders (Verification vs Challenge)
 - **Verification ladder**: `generate_verification_ladder()` (alias `generate_ladder()`) reveals p/q for regression and CI. Packaged at `src/cellview/data/validation_ladder.yaml`.
 - **Challenge ladder**: `generate_challenge_ladder()` withholds p/q (factors_revealed=False) but keeps identical Ns/seeds; packaged at `src/cellview/data/challenge_ladder.yaml`. Use it for blind factoring runs.
@@ -54,8 +57,9 @@ This is not a practical competitor to GNFS / deployed RSA.
 ## CLI in Brief
 - Entry: `python -m cellview.cli.run_cellview`
 - Modes: `--mode challenge` (canonical 127-bit N) or `--mode validation` with `--override-n` for small Ns.
-- Candidate domains: corridor/dense bands, validation full-domain, or file-based candidates.
+- Candidate domains: corridor/dense bands, validation full-domain, file-based candidates, or the new two-stage `--corridor-mode`.
+- Corridor meta-cells: `--corridor-mode --corridor-count 20000 --corridor-halfwidth 1000000 --corridor-samples 256 --corridor-topk 8 --corridor-agg p5 --corridor-range 1000000000:5000000000`
 - Outputs: JSON log with ranked candidates, DG/aggregation traces, certification results.
 
 ## Logs
-Written to `logs/` with run config, RNG seed, swap counts, metrics over time, ranked candidates, and certification payloads for audit or visualization.
+Written to `logs/` with run config, RNG seed, swap counts, metrics over time, ranked candidates, and certification payloads for audit or visualization. Corridor mode adds Stage-1 metadata: corridor window, energy aggregator, top-ranked corridors, and Levin swap counts for the corridor sort.

--- a/src/cellview/utils/corridors.py
+++ b/src/cellview/utils/corridors.py
@@ -1,0 +1,199 @@
+"""
+Corridor (meta-cell) generation and ranking utilities.
+
+Stage-1 of the meta-cell pipeline ranks *ranges* (corridors) by a
+geometric energy surrogate before expanding the top corridors into
+atomic integer candidates for the regular Levin sorter.
+
+This keeps the search global-but-cheap for 127-bit scale numbers.
+"""
+
+from dataclasses import dataclass
+from decimal import Decimal
+from math import isqrt
+from typing import Dict, Iterable, List, Sequence, Tuple
+
+from cellview.heuristics.core import EnergySpec, resolve_energy
+
+
+@dataclass
+class Corridor:
+    center: int
+    low: int
+    high: int
+    energy: Decimal | None = None
+
+    @property
+    def span(self) -> int:
+        return self.high - self.low + 1
+
+
+def _percentile(values: Sequence[Decimal], p: float) -> Decimal:
+    assert 0 <= p <= 100
+    if not values:
+        return Decimal(0)
+    idx = max(0, min(len(values) - 1, int(len(values) * p / 100)))
+    return sorted(values)[idx]
+
+
+def generate_corridors(
+    range_start: int,
+    range_end: int,
+    half_width: int,
+    num_corridors: int,
+    rng,
+) -> List[Corridor]:
+    """
+    Evenly sweep [range_start, range_end] with num_corridors centers and small jitter.
+    Corridors are clamped to [2, range_end].
+    """
+
+    if num_corridors <= 0:
+        raise ValueError("num_corridors must be positive")
+    if range_end <= range_start:
+        raise ValueError("range_end must exceed range_start")
+
+    span = range_end - range_start
+    step = max(1, span // max(1, num_corridors - 1))
+    centers: List[int] = []
+    for i in range(num_corridors):
+        base = range_start + i * step
+        jitter_cap = max(1, min(half_width // 2, step // 2))
+        jitter = rng.randint(-jitter_cap, jitter_cap)
+        center = max(range_start, min(range_end, base + jitter))
+        centers.append(center)
+
+    corridors: List[Corridor] = []
+    for center in centers:
+        low = max(2, center - half_width)
+        high = min(range_end, center + half_width)
+        if low > high:
+            continue
+        corridors.append(Corridor(center=center, low=low, high=high))
+    return corridors
+
+
+def score_corridor(
+    corridor: Corridor,
+    N: int,
+    energy_spec: EnergySpec,
+    samples: int,
+    rng,
+    aggregator: str = "p5",
+    energy_cache: Dict[tuple, Decimal] | None = None,
+) -> Decimal:
+    """
+    Compute a scalar energy for a corridor by sampling integer cells inside it.
+    aggregator: "min" or "p{percent}" (e.g. "p5" for 5th percentile).
+    """
+
+    energy_cache = energy_cache or {}
+    span = corridor.span
+    count = span if samples >= span else samples
+
+    seen = set()
+    energies: List[Decimal] = []
+    while len(energies) < count:
+        val = rng.randrange(corridor.low, corridor.high + 1)
+        if val in seen:
+            continue
+        seen.add(val)
+        cache_key = (energy_spec.name, val)
+        if cache_key in energy_cache:
+            e_val = energy_cache[cache_key]
+        else:
+            e_val = energy_spec.fn(val, N, energy_spec.params)
+            energy_cache[cache_key] = e_val
+        energies.append(e_val)
+
+    if aggregator == "min":
+        agg = min(energies)
+    elif aggregator.startswith("p"):
+        try:
+            pct = float(aggregator[1:])
+        except ValueError as exc:  # pragma: no cover - defensive
+            raise ValueError(f"Bad percentile aggregator '{aggregator}'") from exc
+        agg = _percentile(energies, pct)
+    else:  # pragma: no cover - defensive
+        raise ValueError(f"Unknown aggregator '{aggregator}'")
+
+    corridor.energy = agg
+    return agg
+
+
+def levin_sort_corridors(corridors: List[Corridor], max_steps: int = 10) -> Dict:
+    """
+    Levin-style neighbor swap sort on corridors using their precomputed energy.
+    Returns metrics mirroring the main engine shape.
+    """
+
+    swaps_per_step: List[int] = []
+    for _ in range(max_steps):
+        swaps = 0
+        for i in range(len(corridors) - 1):
+            a = corridors[i]
+            b = corridors[i + 1]
+            if a.energy is None or b.energy is None:
+                raise ValueError("Corridor energies must be precomputed before sorting")
+            if a.energy > b.energy:
+                corridors[i], corridors[i + 1] = corridors[i + 1], corridors[i]
+                swaps += 1
+        swaps_per_step.append(swaps)
+        if swaps == 0:
+            break
+
+    final_state = [
+        {"index": idx, "center": c.center, "low": c.low, "high": c.high, "energy": str(c.energy)}
+        for idx, c in enumerate(corridors)
+    ]
+
+    ranked = sorted(final_state, key=lambda x: Decimal(x["energy"]))
+    return {
+        "swaps_per_step": swaps_per_step,
+        "final_state": final_state,
+        "ranked_corridors": ranked,
+    }
+
+
+def expand_corridors_to_candidates(corridors: Sequence[Corridor]) -> List[int]:
+    """
+    Expand corridors into dense integer candidate list, deduped and ordered by corridor rank.
+    """
+
+    seen = set()
+    out: List[int] = []
+    for c in corridors:
+        for val in range(c.low, c.high + 1):
+            if val not in seen:
+                seen.add(val)
+                out.append(val)
+    return out
+
+
+def default_range_for(N: int, start: int | None, end: int | None) -> Tuple[int, int]:
+    """Fallback corridor search window.
+
+    If explicit start/end provided, honor them.
+    For the canonical 127-bit challenge we bias to the 2^31..5e9 window
+    where prior resonance points cluster; otherwise default to [2, sqrt(N)].
+    """
+
+    if start and end:
+        return start, end
+
+    sqrt_n = isqrt(N)
+
+    if N > 10**30:  # heuristic cue for the 127-bit scale
+        return 1_000_000_000, 5_000_000_000
+
+    return 2, sqrt_n
+
+
+__all__ = [
+    "Corridor",
+    "generate_corridors",
+    "score_corridor",
+    "levin_sort_corridors",
+    "expand_corridors_to_candidates",
+    "default_range_for",
+]


### PR DESCRIPTION
## Summary
1. Introduce meta-cell corridor layer (src/cellview/utils/corridors.py) with corridor structs, percentile/min energy scoring over sampled candidates, Levin neighbor sort on corridors, dense expansion, and a challenge-biased default range helper.
2. Wire corridor mode into CLI (cellview.cli.run_cellview): new flags for corridor counts/halfwidths/samples/top-k/aggregator/range; Stage-1 metadata is printed and persisted in logs; Stage-2 reuses the existing engine + trial certification with guardrails intact.
3. Document the hierarchical approach in README: why corridors fix 127-bit scaling, how to invoke the mode, and what extra telemetry appears in logs.

## Rationale
- The 127-bit gate was bottlenecked by manual dense-band guessing. Corridors let the geometry triage the entire 2^31–2^32 region cheaply, then zoom only on the most resonant bands, keeping memory bounded while staying within the same geofac+trial flow (no Pollard/GNFS).

## Implementation Notes
- Corridor scoring supports "min" or percentile (e.g., "p5") aggregators; energies cached by (algotype, n) for reuse during sampling.
- Default corridor range: [1e9, 5e9] for large N; otherwise [2, sqrt(N)]. Halfwidth and count are user-tunable; centers get deterministic jitter from the CLI seed.
- Stage-1 outputs (range, corridor count, halfwidth, samples, agg, top corridors, corridor Levin swaps) are included under stage1_corridors in run logs.
- Challenge guardrails preserved: candidate-count safety check still enforced after expansion.

## Runs / Logs
- Validation smoke: PYTHONPATH=src python -m cellview.cli.run_cellview --mode validation --override-n 481 --corridor-mode --corridor-count 200 --corridor-halfwidth 20 --corridor-samples 8 --corridor-topk 4 --max-steps 5 --top-m 5  → factors found; log logs/run_1765021736052.json.
- G127 attempt: PYTHONPATH=src python -m cellview.cli.run_cellview --mode challenge --corridor-mode --corridor-count 8000 --corridor-halfwidth 400000 --corridor-samples 128 --corridor-topk 8 --max-steps 18 --top-m 50 --seed-hex aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa  → 6,400,008 candidates expanded; no factor; log logs/run_1765022481922.json.
- Two heavier configs (20k & 12k corridors with larger halfwidths) were aborted on runtime; kept in notes, not in logs.

## Testing
- pytest -q
- Validation corridor smoke (command above)
- G127 corridor run (command above)

## Follow-ups proposed
- Sweep multiple seeds with similar corridor budgets to map recurrent low-energy corridors; widen/shift range if needed.
- Optional: small helper to accumulate corridor minima across runs and auto-tune the next band expansion.

Untracked file left untouched: .snapshots/snapshot-2025-12-06-06_30_17.md.